### PR TITLE
Added API methods to get and set alternative textures for a specific object instance.

### DIFF
--- a/AlternativeTextures/Framework/Interfaces/API/Api.cs
+++ b/AlternativeTextures/Framework/Interfaces/API/Api.cs
@@ -1,4 +1,5 @@
-﻿using AlternativeTextures.Framework.Models;
+﻿using AlternativeTextures.Framework.Managers;
+using AlternativeTextures.Framework.Models;
 using AlternativeTextures.Framework.Patches;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -18,6 +19,7 @@ namespace AlternativeTextures.Framework.Interfaces.API
         public void AddAlternativeTexture(AlternativeTextureModel model, string owner, List<Texture2D> textures);
         public Texture2D GetTextureForObject(Object obj, out Rectangle sourceRect);
         public void SetTextureForObject(Object obj);
+        public void SetTextureForObject(Object obj, string texturePackId, string optionalSeason = null, int optionalVariation = 0);
     }
 
     public class Api : IApi
@@ -217,6 +219,32 @@ namespace AlternativeTextures.Framework.Interfaces.API
             }
 
             PatchTemplate.AssignDefaultModData(obj, instanceSeasonName, true, obj.bigCraftable.Value);
+        }
+
+        public void SetTextureForObject(Object obj, string texturePackId, string optionalSeason = null, int optionalVariation = 0)
+        {
+            if (obj is null)
+            {
+                return;
+            }
+
+            var modelType = PatchTemplate.GetTextureType(obj);
+            var instanceName = $"{modelType}_{PatchTemplate.GetObjectName(obj)}";
+            if (String.IsNullOrEmpty(optionalSeason) is false)
+            {
+                optionalSeason = optionalSeason.ToLower();
+                instanceName = $"{instanceName}_{optionalSeason}";
+            }
+            var modelName = String.Concat(texturePackId, ".", instanceName);
+
+            // Verify texture exists before applying change
+            if (AlternativeTextures.textureManager.DoesObjectHaveAlternativeTextureById(modelName))
+            {
+                obj.modData["AlternativeTextureOwner"] = texturePackId;
+                obj.modData["AlternativeTextureName"] = modelName;
+                obj.modData["AlternativeTextureVariation"] = optionalVariation.ToString();
+                obj.modData["AlternativeTextureSeason"] = String.IsNullOrEmpty(optionalSeason) ? String.Empty : optionalSeason;
+            }
         }
     }
 }

--- a/AlternativeTextures/Framework/Interfaces/API/Api.cs
+++ b/AlternativeTextures/Framework/Interfaces/API/Api.cs
@@ -172,41 +172,13 @@ namespace AlternativeTextures.Framework.Interfaces.API
             // Override xTileOffset if AlternativeTextureModel has an animation
             if (textureModel.HasAnimation(textureVariation))
             {
-                if (!obj.modData.ContainsKey("AlternativeTextureCurrentFrame") || !obj.modData.ContainsKey("AlternativeTextureFrameIndex") || !obj.modData.ContainsKey("AlternativeTextureFrameDuration") || !obj.modData.ContainsKey("AlternativeTextureElapsedDuration"))
-                {
-                    obj.modData["AlternativeTextureCurrentFrame"] = "0";
-                    obj.modData["AlternativeTextureFrameIndex"] = "0";
-                    obj.modData["AlternativeTextureFrameDuration"] = textureModel.GetAnimationDataAtIndex(textureVariation, 0).Duration.ToString();// Animation.ElementAt(0).Duration.ToString();
-                    obj.modData["AlternativeTextureElapsedDuration"] = "0";
-                }
-
-                var currentFrame = int.Parse(obj.modData["AlternativeTextureCurrentFrame"]);
-                var frameIndex = int.Parse(obj.modData["AlternativeTextureFrameIndex"]);
-                var frameDuration = int.Parse(obj.modData["AlternativeTextureFrameDuration"]);
-                var elapsedDuration = int.Parse(obj.modData["AlternativeTextureElapsedDuration"]);
-
-                if (elapsedDuration >= frameDuration)
-                {
-                    frameIndex = frameIndex + 1 >= textureModel.GetAnimationData(textureVariation).Count() ? 0 : frameIndex + 1;
-
-                    var animationData = textureModel.GetAnimationDataAtIndex(textureVariation, frameIndex);
-                    currentFrame = animationData.Frame;
-
-                    obj.modData["AlternativeTextureCurrentFrame"] = currentFrame.ToString();
-                    obj.modData["AlternativeTextureFrameIndex"] = frameIndex.ToString();
-                    obj.modData["AlternativeTextureFrameDuration"] = animationData.Duration.ToString();
-                    obj.modData["AlternativeTextureElapsedDuration"] = "0";
-                }
-                else
-                {
-                    obj.modData["AlternativeTextureElapsedDuration"] = (elapsedDuration + Game1.currentGameTime.ElapsedGameTime.Milliseconds).ToString();
-                }
-
-                xTileOffset = currentFrame;
+                xTileOffset = obj.modData.ContainsKey("AlternativeTextureCurrentFrame") is false ? 0 : int.Parse(obj.modData["AlternativeTextureCurrentFrame"]);
             }
             sourceRect = new Rectangle(xTileOffset * textureModel.TextureWidth, textureOffset, textureModel.TextureWidth, textureModel.TextureHeight);
+
             return textureModel.GetTexture(textureVariation);
         }
+
         public void SetTextureForObject(Object obj)
         {
 

--- a/AlternativeTextures/Framework/Interfaces/API/Api.cs
+++ b/AlternativeTextures/Framework/Interfaces/API/Api.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework.Graphics;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Objects;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Object = StardewValley.Object;
@@ -35,7 +36,7 @@ namespace AlternativeTextures.Framework.Interfaces.API
 
         public void AddAlternativeTexture(AlternativeTextureModel model, string owner, List<Texture2D> textures)
         {
-            if (string.IsNullOrEmpty(owner))
+            if (String.IsNullOrEmpty(owner))
             {
                 _framework.Monitor.Log($"Unable to add AlternativeTextureModel {model.GetNameWithSeason()}: Owner property is not set.");
                 return;
@@ -74,11 +75,11 @@ namespace AlternativeTextures.Framework.Interfaces.API
                 }
 
                 // Set the season (if any)
-                textureModel.Season = seasons.Count() == 0 ? string.Empty : seasons[s];
+                textureModel.Season = seasons.Count() == 0 ? String.Empty : seasons[s];
 
                 // Set the ModelName and TextureId
-                textureModel.ModelName = string.IsNullOrEmpty(textureModel.Season) ? string.Concat(textureModel.GetTextureType(), "_", textureModel.ItemName) : string.Concat(textureModel.GetTextureType(), "_", textureModel.ItemName, "_", textureModel.Season);
-                textureModel.TextureId = string.Concat(textureModel.Owner, ".", textureModel.ModelName);
+                textureModel.ModelName = String.IsNullOrEmpty(textureModel.Season) ? String.Concat(textureModel.GetTextureType(), "_", textureModel.ItemName) : String.Concat(textureModel.GetTextureType(), "_", textureModel.ItemName, "_", textureModel.Season);
+                textureModel.TextureId = String.Concat(textureModel.Owner, ".", textureModel.ModelName);
 
                 // Verify we are given a singular texture, if not then stitch them all together
                 if (textures.Count() > 1)
@@ -100,12 +101,12 @@ namespace AlternativeTextures.Framework.Interfaces.API
                         variation++;
                     }
 
-                    textureModel.TileSheetPath = string.Empty;
+                    textureModel.TileSheetPath = String.Empty;
                 }
                 else
                 {
                     // Load in the single vertical texture
-                    textureModel.TileSheetPath = string.Empty;
+                    textureModel.TileSheetPath = String.Empty;
                     Texture2D singularTexture = textures.First();
                     if (singularTexture.Height >= AlternativeTextureModel.MAX_TEXTURE_HEIGHT)
                     {

--- a/AlternativeTextures/Framework/Interfaces/API/Api.cs
+++ b/AlternativeTextures/Framework/Interfaces/API/Api.cs
@@ -215,7 +215,7 @@ namespace AlternativeTextures.Framework.Interfaces.API
                 return;
             }
 
-            var modelType = obj is Furniture ? AlternativeTextureModel.TextureType.Furniture : AlternativeTextureModel.TextureType.Craftable;
+            var modelType = PatchTemplate.GetTextureType(obj);
             var instanceName = $"{modelType}_{PatchTemplate.GetObjectName(obj)}";
             var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
             if (PatchTemplate.HasCachedTextureName(obj) is true)

--- a/AlternativeTextures/Framework/Interfaces/API/Api.cs
+++ b/AlternativeTextures/Framework/Interfaces/API/Api.cs
@@ -20,6 +20,7 @@ namespace AlternativeTextures.Framework.Interfaces.API
         public Texture2D GetTextureForObject(Object obj, out Rectangle sourceRect);
         public void SetTextureForObject(Object obj);
         public void SetTextureForObject(Object obj, string texturePackId, string optionalSeason = null, int optionalVariation = 0);
+        public void ClearTextureForObject(Object obj);
     }
 
     public class Api : IApi
@@ -245,6 +246,22 @@ namespace AlternativeTextures.Framework.Interfaces.API
                 obj.modData["AlternativeTextureVariation"] = optionalVariation.ToString();
                 obj.modData["AlternativeTextureSeason"] = String.IsNullOrEmpty(optionalSeason) ? String.Empty : optionalSeason;
             }
+        }
+
+        public void ClearTextureForObject(Object obj)
+        {
+            if (obj is null)
+            {
+                return;
+            }
+
+            var modelType = PatchTemplate.GetTextureType(obj);
+            var instanceName = $"{modelType}_{PatchTemplate.GetObjectName(obj)}";
+
+            obj.modData["AlternativeTextureOwner"] = AlternativeTextures.DEFAULT_OWNER;
+            obj.modData["AlternativeTextureName"] = $"{AlternativeTextures.DEFAULT_OWNER}.{instanceName}";
+            obj.modData["AlternativeTextureVariation"] = $"{-1}";
+            obj.modData["AlternativeTextureSeason"] = String.Empty;
         }
     }
 }

--- a/AlternativeTextures/Framework/Interfaces/API/Api.cs
+++ b/AlternativeTextures/Framework/Interfaces/API/Api.cs
@@ -148,8 +148,11 @@ namespace AlternativeTextures.Framework.Interfaces.API
         public Texture2D GetTextureForObject(Object obj, out Rectangle sourceRect)
         {
             sourceRect = new Rectangle();
-            if (!obj.modData.TryGetValue("AlternativeTextureName", out var str))
+            if (obj.modData.TryGetValue("AlternativeTextureName", out var str) is false)
+            {
                 return null;
+            }
+
             var textureModel = AlternativeTextures.textureManager.GetSpecificTextureModel(str);
             if (textureModel is null)
             {
@@ -181,7 +184,6 @@ namespace AlternativeTextures.Framework.Interfaces.API
 
         public void SetTextureForObject(Object obj)
         {
-
             if (obj is null)
             {
                 return;
@@ -196,7 +198,7 @@ namespace AlternativeTextures.Framework.Interfaces.API
             }
             else if (AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceName) && AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceSeasonName))
             {
-                var result = Game1.random.Next(2) > 0 ? PatchTemplate.AssignModData(obj, instanceSeasonName, true, obj.bigCraftable.Value) : PatchTemplate.AssignModData(obj, instanceName, false, obj.bigCraftable.Value);
+                _ = Game1.random.Next(2) > 0 ? PatchTemplate.AssignModData(obj, instanceSeasonName, true, obj.bigCraftable.Value) : PatchTemplate.AssignModData(obj, instanceName, false, obj.bigCraftable.Value);
                 return;
             }
             else


### PR DESCRIPTION
Hi, I'm interested in being able to set AT modData for a specific object and use that modData to return a Texture2D and source rect for an object. I've added two methods to the API that do that, and have tested it to be working for me. 

Thanks in advance for your consideration.