### PR TITLE
Add support for all buildable locations

### DIFF
--- a/AlternativeTextures/AlternativeTextures.cs
+++ b/AlternativeTextures/AlternativeTextures.cs
@@ -417,7 +417,7 @@ namespace AlternativeTextures
                 var modelType = placedObject is Furniture ? AlternativeTextureModel.TextureType.Furniture : AlternativeTextureModel.TextureType.Craftable;
                 if (!placedObject.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME) || !placedObject.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_VARIATION))
                 {
-                    var instanceSeasonName = $"{modelType}_{PatchTemplate.GetObjectName(placedObject)}_{Game1.currentSeason}";
+                    var instanceSeasonName = $"{modelType}_{PatchTemplate.GetObjectName(placedObject)}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                     PatchTemplate.AssignDefaultModData(placedObject, instanceSeasonName, true);
                 }
 
@@ -629,9 +629,9 @@ namespace AlternativeTextures
                 }
                 else
                 {
-                    if (Game1.currentLocation is Farm farm)
+                    if (Game1.currentLocation.IsBuildableLocation())
                     {
-                        var targetedBuilding = farm.getBuildingAt(new Vector2(xTile / 64, yTile / 64));
+                        var targetedBuilding = Game1.currentLocation.getBuildingAt(new Vector2(xTile / 64, yTile / 64));
                         if (targetedBuilding != null)
                         {
                             Game1.addHUDMessage(new HUDMessage(modHelper.Translation.Get("messages.warning.spray_can_not_supported"), 3) { timeLeft = 2000 });
@@ -650,7 +650,7 @@ namespace AlternativeTextures
                 var modelType = placedObject is Furniture ? AlternativeTextureModel.TextureType.Furniture : AlternativeTextureModel.TextureType.Craftable;
                 if (!placedObject.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME) || !placedObject.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_VARIATION))
                 {
-                    var instanceSeasonName = $"{modelType}_{PatchTemplate.GetObjectName(placedObject)}_{Game1.currentSeason}";
+                    var instanceSeasonName = $"{modelType}_{PatchTemplate.GetObjectName(placedObject)}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                     PatchTemplate.AssignDefaultModData(placedObject, instanceSeasonName, true);
                 }
 
@@ -1326,9 +1326,9 @@ namespace AlternativeTextures
                 return;
             }
 
-            if (!(Game1.currentLocation is Farm))
+            if (!(Game1.currentLocation.GetData()?.CanPlantHere ?? Game1.currentLocation.IsFarm) || (Game1.currentLocation is not Farm && !Game1.currentLocation.HasMapPropertyWithValue("AllowGiantCrops")))
             {
-                Monitor.Log($"Command can only be used on player's farm.", LogLevel.Warn);
+                Monitor.Log($"Command can only be used on a plantable location allowing giant crops.", LogLevel.Warn);
                 return;
             }
 
@@ -1363,7 +1363,7 @@ namespace AlternativeTextures
                         }
                     }
 
-                    (environment as Farm).resourceClumps.Add(new GiantCrop(args[0], new Vector2(xTile - 1, yTile - 1)));
+                    environment.resourceClumps.Add(new GiantCrop(args[0], new Vector2(xTile - 1, yTile - 1)));
                 }
             }
         }
@@ -1376,9 +1376,9 @@ namespace AlternativeTextures
                 return;
             }
 
-            if (!(Game1.currentLocation is Farm))
+            if (!Game1.currentLocation.IsOutdoors)
             {
-                Monitor.Log($"Command can only be used on player's farm.", LogLevel.Warn);
+                Monitor.Log($"Command can only be used outdoors.", LogLevel.Warn);
                 return;
             }
 
@@ -1388,7 +1388,7 @@ namespace AlternativeTextures
                 return;
             }
 
-            (Game1.currentLocation as Farm).resourceClumps.Add(new ResourceClump(600, 2, 2, Game1.player.Tile + new Vector2(1, 1)));
+            Game1.currentLocation.resourceClumps.Add(new ResourceClump(600, 2, 2, Game1.player.Tile + new Vector2(1, 1)));
         }
 
         private void DebugSpawnChild(string command, string[] args)

--- a/AlternativeTextures/Framework/Interfaces/API/Api.cs
+++ b/AlternativeTextures/Framework/Interfaces/API/Api.cs
@@ -192,7 +192,7 @@ namespace AlternativeTextures.Framework.Interfaces.API
 
             var modelType = PatchTemplate.GetTextureType(obj);
             var instanceName = $"{modelType}_{PatchTemplate.GetObjectName(obj)}";
-            var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
+            var instanceSeasonName = $"{instanceName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
             if (PatchTemplate.HasCachedTextureName(obj) is true)
             {
                 return;

--- a/AlternativeTextures/Framework/Patches/Buildings/BuildingPatch.cs
+++ b/AlternativeTextures/Framework/Patches/Buildings/BuildingPatch.cs
@@ -45,14 +45,14 @@ namespace AlternativeTextures.Framework.Patches.Buildings
             }
 
             var instanceName = String.Concat(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER], ".", $"{AlternativeTextureModel.TextureType.Building}_{GetBuildingName(__instance)}");
-            var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
+            var instanceSeasonName = $"{instanceName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
 
             if (!String.Equals(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME], instanceName, StringComparison.OrdinalIgnoreCase) && !String.Equals(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME], instanceSeasonName, StringComparison.OrdinalIgnoreCase))
             {
                 __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = String.Concat(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER], ".", $"{AlternativeTextureModel.TextureType.Building}_{GetBuildingName(__instance)}");
                 if (__instance.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]))
                 {
-                    __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.currentSeason;
+                    __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.GetSeasonForLocation(Game1.currentLocation).ToString();
                     __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = String.Concat(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME], "_", __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]);
 
                     __instance.resetTexture();
@@ -217,7 +217,7 @@ namespace AlternativeTextures.Framework.Patches.Buildings
             // Handle Greenhouse logic
             if (__instance.buildingType.Value == "Greenhouse")
             {
-                Farm farm = __instance.GetParentLocation() as Farm;
+                Farm farm = Game1.getFarm();
                 if (farm is not null && farm.greenhouseUnlocked.Value is false)
                 {
                     yOffset -= buildingData.SourceRect.Height;
@@ -446,7 +446,7 @@ namespace AlternativeTextures.Framework.Patches.Buildings
         private static void BuildingPostfix(Building __instance, string type, Vector2 tile)
         {
             var instanceName = $"{AlternativeTextureModel.TextureType.Building}_{GetBuildingName(__instance)}";
-            var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
+            var instanceSeasonName = $"{instanceName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
 
             if (AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceName) && AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceSeasonName))
             {

--- a/AlternativeTextures/Framework/Patches/GameLocations/GameLocationPatch.cs
+++ b/AlternativeTextures/Framework/Patches/GameLocations/GameLocationPatch.cs
@@ -78,7 +78,7 @@ namespace AlternativeTextures.Framework.Patches.GameLocations
                         }
 
                         var seasonalName = String.Concat(obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER], ".", $"{AlternativeTextureModel.TextureType.Craftable}_{instanceName}_{season}");
-                        if ((obj.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]) && !String.Equals(obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON], Game1.currentSeason, StringComparison.OrdinalIgnoreCase)) || AlternativeTextures.textureManager.DoesObjectHaveAlternativeTextureById(seasonalName))
+                        if ((obj.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]) && !String.Equals(obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON], Game1.GetSeasonForLocation(Game1.currentLocation).ToString(), StringComparison.OrdinalIgnoreCase)) || AlternativeTextures.textureManager.DoesObjectHaveAlternativeTextureById(seasonalName))
                         {
                             obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = season.ToString();
                             obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = seasonalName;
@@ -97,7 +97,7 @@ namespace AlternativeTextures.Framework.Patches.GameLocations
                         var instanceName = GetCharacterName(character);
 
                         var seasonalName = String.Concat(character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER], ".", $"{AlternativeTextureModel.TextureType.Character}_{instanceName}_{season}");
-                        if ((character.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]) && !String.Equals(character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON], Game1.currentSeason, StringComparison.OrdinalIgnoreCase)) || AlternativeTextures.textureManager.DoesObjectHaveAlternativeTextureById(seasonalName))
+                        if ((character.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]) && !String.Equals(character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON], Game1.GetSeasonForLocation(Game1.currentLocation).ToString(), StringComparison.OrdinalIgnoreCase)) || AlternativeTextures.textureManager.DoesObjectHaveAlternativeTextureById(seasonalName))
                         {
                             character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = season.ToString();
                             character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = seasonalName;
@@ -118,7 +118,7 @@ namespace AlternativeTextures.Framework.Patches.GameLocations
                         var instanceName = GetCharacterName(farmAnimal);
 
                         var seasonalName = String.Concat(farmAnimal.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER], ".", $"{AlternativeTextureModel.TextureType.Character}_{instanceName}_{season}");
-                        if ((farmAnimal.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(farmAnimal.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]) && !String.Equals(farmAnimal.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON], Game1.currentSeason, StringComparison.OrdinalIgnoreCase)) || AlternativeTextures.textureManager.DoesObjectHaveAlternativeTextureById(seasonalName))
+                        if ((farmAnimal.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(farmAnimal.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]) && !String.Equals(farmAnimal.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON], Game1.GetSeasonForLocation(Game1.currentLocation).ToString(), StringComparison.OrdinalIgnoreCase)) || AlternativeTextures.textureManager.DoesObjectHaveAlternativeTextureById(seasonalName))
                         {
                             farmAnimal.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = season.ToString();
                             farmAnimal.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = seasonalName;
@@ -127,7 +127,7 @@ namespace AlternativeTextures.Framework.Patches.GameLocations
                 }
             }
 
-            if (__instance is Farm houseFarm && __instance.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_OWNER) is true && __instance.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME) is true)
+            if (__instance.IsBuildableLocation() && __instance.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_OWNER) is true && __instance.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME) is true)
             {
                 var buildingType = $"Farmhouse_{Game1.MasterPlayer.HouseUpgradeLevel}";
                 if (!__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME].Contains(buildingType))
@@ -136,14 +136,14 @@ namespace AlternativeTextures.Framework.Patches.GameLocations
                 }
 
                 var instanceName = String.Concat(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER], ".", $"{AlternativeTextureModel.TextureType.Building}_{buildingType}");
-                var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
+                var instanceSeasonName = $"{instanceName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
 
                 if (!String.Equals(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME], instanceName, StringComparison.OrdinalIgnoreCase) && !String.Equals(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME], instanceSeasonName, StringComparison.OrdinalIgnoreCase))
                 {
                     __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = String.Concat(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER], ".", $"{AlternativeTextureModel.TextureType.Building}_{buildingType}");
                     if (__instance.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]))
                     {
-                        __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.currentSeason;
+                        __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.GetSeasonForLocation(Game1.currentLocation).ToString();
                         __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = String.Concat(__instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME], "_", __instance.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]);
                     }
                 }

--- a/AlternativeTextures/Framework/Patches/PatchTemplate.cs
+++ b/AlternativeTextures/Framework/Patches/PatchTemplate.cs
@@ -255,9 +255,9 @@ namespace AlternativeTextures.Framework.Patches
         {
             var tileLocation = new Vector2(x / 64, y / 64);
             var rectangle = new Rectangle(x, y, 64, 64);
-            if (location is Farm farm)
+            if (location.IsBuildableLocation())
             {
-                foreach (var animal in farm.animals.Values)
+                foreach (var animal in location.animals.Values)
                 {
                     if (animal.GetBoundingBox().Intersects(rectangle))
                     {
@@ -458,7 +458,7 @@ namespace AlternativeTextures.Framework.Patches
                 return false;
             }
 
-            var textureModel = new AlternativeTextureModel() { Owner = AlternativeTextures.DEFAULT_OWNER, Season = trackSeason ? Game1.currentSeason : String.Empty };
+            var textureModel = new AlternativeTextureModel() { Owner = AlternativeTextures.DEFAULT_OWNER, Season = trackSeason ? Game1.GetSeasonForLocation(Game1.currentLocation).ToString() : String.Empty };
             switch (type)
             {
                 case Object obj:
@@ -476,8 +476,8 @@ namespace AlternativeTextures.Framework.Patches
                 case DecoratableLocation decoratableLocation:
                     AssignDecoratableLocationModData(decoratableLocation, modelName, textureModel, -1, trackSeason);
                     return true;
-                case Farm farm:
-                    AssignFarmModData(farm, modelName, textureModel, -1, trackSeason);
+                case GameLocation gameLocation when gameLocation.IsBuildableLocation():
+                    AssignGameLocationModData(gameLocation, modelName, textureModel, -1, trackSeason);
                     return true;
             }
 
@@ -541,7 +541,7 @@ namespace AlternativeTextures.Framework.Patches
 
             if (trackSeason && !String.IsNullOrEmpty(textureModel.Season))
             {
-                obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.currentSeason;
+                obj.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.GetSeasonForLocation(Game1.currentLocation).ToString();
             }
 
             if (trackSheetId)
@@ -585,7 +585,7 @@ namespace AlternativeTextures.Framework.Patches
 
             if (trackSeason && !String.IsNullOrEmpty(textureModel.Season))
             {
-                building.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.currentSeason;
+                building.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.GetSeasonForLocation(Game1.currentLocation).ToString();
             }
 
             building.modData[ModDataKeys.ALTERNATIVE_TEXTURE_VARIATION] = variation.ToString();
@@ -598,23 +598,23 @@ namespace AlternativeTextures.Framework.Patches
 
             if (trackSeason && !String.IsNullOrEmpty(textureModel.Season))
             {
-                decoratableLocation.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.currentSeason;
+                decoratableLocation.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.GetSeasonForLocation(Game1.currentLocation).ToString();
             }
 
             decoratableLocation.modData[ModDataKeys.ALTERNATIVE_TEXTURE_VARIATION] = variation.ToString();
         }
 
-        private static void AssignFarmModData(Farm farm, string modelName, AlternativeTextureModel textureModel, int variation, bool trackSeason = false)
+        private static void AssignGameLocationModData(GameLocation gameLocation, string modelName, AlternativeTextureModel textureModel, int variation, bool trackSeason = false)
         {
-            farm.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER] = textureModel.Owner;
-            farm.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = String.Concat(textureModel.Owner, ".", modelName);
+            gameLocation.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER] = textureModel.Owner;
+            gameLocation.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME] = String.Concat(textureModel.Owner, ".", modelName);
 
             if (trackSeason && !String.IsNullOrEmpty(textureModel.Season))
             {
-                farm.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.currentSeason;
+                gameLocation.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON] = Game1.GetSeasonForLocation(Game1.currentLocation).ToString();
             }
 
-            farm.modData[ModDataKeys.ALTERNATIVE_TEXTURE_VARIATION] = variation.ToString();
+            gameLocation.modData[ModDataKeys.ALTERNATIVE_TEXTURE_VARIATION] = variation.ToString();
         }
     }
 }

--- a/AlternativeTextures/Framework/Patches/StandardObjects/FencePatch.cs
+++ b/AlternativeTextures/Framework/Patches/StandardObjects/FencePatch.cs
@@ -157,7 +157,7 @@ namespace AlternativeTextures.Framework.Patches.StandardObjects
             if (dropInItem.parentSheetIndex == 325 && __result)
             {
                 var instanceName = $"{AlternativeTextureModel.TextureType.Craftable}_{Game1.objectData[dropInItem.ItemId].Name}";
-                var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
+                var instanceSeasonName = $"{instanceName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
 
                 if (AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceName) && AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceSeasonName))
                 {

--- a/AlternativeTextures/Framework/Patches/StandardObjects/FlooringPatch.cs
+++ b/AlternativeTextures/Framework/Patches/StandardObjects/FlooringPatch.cs
@@ -144,24 +144,24 @@ namespace AlternativeTextures.Framework.Patches.StandardObjects
                 byte drawSum = 0;
                 Vector2 surroundingLocations = tileLocation;
                 surroundingLocations.X += 1f;
-                GameLocation farm = Game1.getLocationFromName("Farm");
-                if (farm.terrainFeatures.ContainsKey(surroundingLocations) && farm.terrainFeatures[surroundingLocations] is Flooring)
+                GameLocation location = __instance.Location;
+                if (location.terrainFeatures.ContainsKey(surroundingLocations) && location.terrainFeatures[surroundingLocations] is Flooring)
                 {
                     drawSum = (byte)(drawSum + 2);
                 }
                 surroundingLocations.X -= 2f;
-                if (farm.terrainFeatures.ContainsKey(surroundingLocations) && Game1.currentLocation.terrainFeatures[surroundingLocations] is Flooring)
+                if (location.terrainFeatures.ContainsKey(surroundingLocations) && location.terrainFeatures[surroundingLocations] is Flooring)
                 {
                     drawSum = (byte)(drawSum + 8);
                 }
                 surroundingLocations.X += 1f;
                 surroundingLocations.Y += 1f;
-                if (Game1.currentLocation.terrainFeatures.ContainsKey(surroundingLocations) && farm.terrainFeatures[surroundingLocations] is Flooring)
+                if (location.terrainFeatures.ContainsKey(surroundingLocations) && location.terrainFeatures[surroundingLocations] is Flooring)
                 {
                     drawSum = (byte)(drawSum + 4);
                 }
                 surroundingLocations.Y -= 2f;
-                if (farm.terrainFeatures.ContainsKey(surroundingLocations) && farm.terrainFeatures[surroundingLocations] is Flooring)
+                if (location.terrainFeatures.ContainsKey(surroundingLocations) && location.terrainFeatures[surroundingLocations] is Flooring)
                 {
                     drawSum = (byte)(drawSum + 1);
                 }

--- a/AlternativeTextures/Framework/Patches/StandardObjects/ObjectPatch.cs
+++ b/AlternativeTextures/Framework/Patches/StandardObjects/ObjectPatch.cs
@@ -288,7 +288,7 @@ namespace AlternativeTextures.Framework.Patches.StandardObjects
                     flooring.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SHEET_ID] = __instance.ParentSheetIndex.ToString();
 
                     var flooringName = $"{AlternativeTextureModel.TextureType.Flooring}_{GetFlooringName(flooring)}";
-                    var flooringSeasonName = $"{flooringName}_{Game1.currentSeason}";
+                    var flooringSeasonName = $"{flooringName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                     if (AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(flooringName) && AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(flooringSeasonName))
                     {
                         var result = Game1.random.Next(2) > 0 ? AssignModData(flooring, flooringSeasonName, true) : AssignModData(flooring, flooringName, false);
@@ -316,7 +316,7 @@ namespace AlternativeTextures.Framework.Patches.StandardObjects
 
             var modelType = placedObject is Furniture ? AlternativeTextureModel.TextureType.Furniture : AlternativeTextureModel.TextureType.Craftable;
             var instanceName = $"{modelType}_{GetObjectName(placedObject)}";
-            var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
+            var instanceSeasonName = $"{instanceName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
 
             if (HasCachedTextureName(__instance) is true)
             {
@@ -354,7 +354,7 @@ namespace AlternativeTextures.Framework.Patches.StandardObjects
             }
 
             var instanceName = $"{AlternativeTextureModel.TextureType.ArtifactSpot}_{GetObjectName(__instance)}";
-            var instanceSeasonName = $"{instanceName}_{Game1.currentSeason}";
+            var instanceSeasonName = $"{instanceName}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
 
             if (AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceName) && AlternativeTextures.textureManager.DoesObjectHaveAlternativeTexture(instanceSeasonName))
             {

--- a/AlternativeTextures/Framework/Patches/Tools/ToolPatch.cs
+++ b/AlternativeTextures/Framework/Patches/Tools/ToolPatch.cs
@@ -218,84 +218,86 @@ namespace AlternativeTextures.Framework.Patches.Tools
 
         internal static bool UsePaintBucket(GameLocation location, int x, int y, Farmer who, bool isSprayCan = false)
         {
-            if (location is Farm farm && isSprayCan is false)
+            if (location.IsBuildableLocation() && isSprayCan is false)
             {
-                var farmerHouse = farm.GetMainFarmHouse();
+                var targetedBuilding = location.getBuildingAt(new Vector2(x / 64, y / 64));
+                bool isFarmerHouse = false;
 
-                // Check for mailbox
-                var mailboxPosition = farm.GetMainMailboxPosition();
-                if (PatchTemplate.IsPositionNearMailbox(location, mailboxPosition, x / 64, y / 64))
+                if (location is Farm farm)
                 {
-                    var modelType = AlternativeTextureModel.TextureType.Building;
-                    if (!location.modData.ContainsKey("AlternativeTextureName.Mailbox") || !location.modData["AlternativeTextureName.Mailbox"].Contains("Mailbox"))
+                    var farmerHouse = farm.GetMainFarmHouse();
+
+                    // Check for mailbox
+                    var mailboxPosition = farm.GetMainMailboxPosition();
+                    if (PatchTemplate.IsPositionNearMailbox(location, mailboxPosition, x / 64, y / 64))
                     {
-                        var textureModel = new AlternativeTextureModel() { Owner = AlternativeTextures.DEFAULT_OWNER, Season = Game1.currentSeason };
-
-                        location.modData["AlternativeTextureOwner.Mailbox"] = textureModel.Owner;
-                        location.modData["AlternativeTextureName.Mailbox"] = String.Concat(textureModel.Owner, ".", $"{modelType}_{"Mailbox"}_{Game1.currentSeason}");
-
-                        if (!String.IsNullOrEmpty(textureModel.Season))
+                        var modelType = AlternativeTextureModel.TextureType.Building;
+                        if (!location.modData.ContainsKey("AlternativeTextureName.Mailbox") || !location.modData["AlternativeTextureName.Mailbox"].Contains("Mailbox"))
                         {
-                            location.modData["AlternativeTextureSeason.Mailbox"] = Game1.currentSeason;
+                            var textureModel = new AlternativeTextureModel() { Owner = AlternativeTextures.DEFAULT_OWNER, Season = Game1.GetSeasonForLocation(Game1.currentLocation).ToString() };
+
+                            location.modData["AlternativeTextureOwner.Mailbox"] = textureModel.Owner;
+                            location.modData["AlternativeTextureName.Mailbox"] = String.Concat(textureModel.Owner, ".", $"{modelType}_{"Mailbox"}_{Game1.GetSeasonForLocation(Game1.currentLocation)}");
+
+                            if (!String.IsNullOrEmpty(textureModel.Season))
+                            {
+                                location.modData["AlternativeTextureSeason.Mailbox"] = Game1.GetSeasonForLocation(Game1.currentLocation).ToString();
+                            }
+
+                            location.modData["AlternativeTextureVariation.Mailbox"] = "-1";
                         }
 
-                        location.modData["AlternativeTextureVariation.Mailbox"] = "-1";
-                    }
+                        bool usedSecondaryTile = string.IsNullOrEmpty(location.doesTileHaveProperty(x / 64, y / 64, "Action", "Buildings")) && location.doesTileHaveProperty(x / 64, (y + 64) / 64, "Action", "Buildings") == "Mailbox";
+                        var mailboxObj = new Object("100", 1, isRecipe: false, -1)
+                        {
+                            TileLocation = new Vector2(x / 64, (y + (usedSecondaryTile ? 64 : 0)) / 64)
+                        };
 
-                    bool usedSecondaryTile = string.IsNullOrEmpty(location.doesTileHaveProperty(x / 64, y / 64, "Action", "Buildings")) && location.doesTileHaveProperty(x / 64, (y + 64) / 64, "Action", "Buildings") == "Mailbox";
-                    var mailboxObj = new Object("100", 1, isRecipe: false, -1)
-                    {
-                        TileLocation = new Vector2(x / 64, (y + (usedSecondaryTile ? 64 : 0)) / 64)
-                    };
+                        foreach (string key in location.modData.Keys)
+                        {
+                            mailboxObj.modData[key] = location.modData[key];
+                        }
 
-                    foreach (string key in location.modData.Keys)
-                    {
-                        mailboxObj.modData[key] = location.modData[key];
-                    }
+                        var modelName = mailboxObj.modData["AlternativeTextureName.Mailbox"].Replace($"{mailboxObj.modData["AlternativeTextureOwner.Mailbox"]}.", String.Empty);
+                        if (mailboxObj.modData.ContainsKey("AlternativeTextureSeason.Mailbox") && !String.IsNullOrEmpty(mailboxObj.modData["AlternativeTextureSeason.Mailbox"]))
+                        {
+                            modelName = GetModelNameWithoutSeason(modelName, mailboxObj.modData["AlternativeTextureSeason.Mailbox"]);
+                        }
 
-                    var modelName = mailboxObj.modData["AlternativeTextureName.Mailbox"].Replace($"{mailboxObj.modData["AlternativeTextureOwner.Mailbox"]}.", String.Empty);
-                    if (mailboxObj.modData.ContainsKey("AlternativeTextureSeason.Mailbox") && !String.IsNullOrEmpty(mailboxObj.modData["AlternativeTextureSeason.Mailbox"]))
-                    {
-                        modelName = GetModelNameWithoutSeason(modelName, mailboxObj.modData["AlternativeTextureSeason.Mailbox"]);
-                    }
+                        if (AlternativeTextures.textureManager.GetAvailableTextureModels(modelName, Game1.GetSeasonForLocation(Game1.currentLocation)).Count == 0)
+                        {
+                            Game1.addHUDMessage(new HUDMessage(_helper.Translation.Get("messages.warning.no_textures_for_season", new { itemName = modelName }), 3));
+                            return CancelUsing(who);
+                        }
 
-                    if (AlternativeTextures.textureManager.GetAvailableTextureModels(modelName, Game1.GetSeasonForLocation(Game1.currentLocation)).Count == 0)
-                    {
-                        Game1.addHUDMessage(new HUDMessage(_helper.Translation.Get("messages.warning.no_textures_for_season", new { itemName = modelName }), 3));
+                        // Display texture menu
+                        Game1.activeClickableMenu = new PaintBucketMenu(mailboxObj, mailboxObj.TileLocation * 64f, TextureType.Craftable, modelName, _helper.Translation.Get("tools.name.paint_bucket"), isSprayCan: false, textureOwnerKey: "AlternativeTextureOwner.Mailbox", textureNameKey: "AlternativeTextureName.Mailbox", textureVariationKey: "AlternativeTextureVariation.Mailbox", textureSeasonKey: "AlternativeTextureSeason.Mailbox", textureDisplayNameKey: "AlternativeTextureDisplayName.Mailbox");
+
                         return CancelUsing(who);
                     }
 
-                    // Display texture menu
-                    Game1.activeClickableMenu = new PaintBucketMenu(mailboxObj, mailboxObj.TileLocation * 64f, TextureType.Craftable, modelName, _helper.Translation.Get("tools.name.paint_bucket"), isSprayCan: false, textureOwnerKey: "AlternativeTextureOwner.Mailbox", textureNameKey: "AlternativeTextureName.Mailbox", textureVariationKey: "AlternativeTextureVariation.Mailbox", textureSeasonKey: "AlternativeTextureSeason.Mailbox", textureDisplayNameKey: "AlternativeTextureDisplayName.Mailbox");
-
-                    return CancelUsing(who);
-                }
-
-
-                var targetedBuilding = farm.getBuildingAt(new Vector2(x / 64, y / 64));
-
-                bool isFarmerHouse = false;
-                if (farmerHouse == targetedBuilding)
-                {
-                    isFarmerHouse = true;
-
-                    targetedBuilding = new Building();
-                    targetedBuilding.buildingType.Value = $"Farmhouse_{Game1.MasterPlayer.HouseUpgradeLevel}";
-                    targetedBuilding.tileX.Value = farmerHouse.tileX.Value;
-                    targetedBuilding.tileY.Value = farmerHouse.tileY.Value;
-                    targetedBuilding.tilesWide.Value = farmerHouse.tilesWide.Value;
-                    targetedBuilding.tilesHigh.Value = farmerHouse.tilesHigh.Value;
-
-                    var modelType = AlternativeTextureModel.TextureType.Building;
-                    if (!farm.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME) || !farm.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME].Contains(targetedBuilding.buildingType.Value))
+                    if (farmerHouse == targetedBuilding)
                     {
-                        var instanceSeasonName = $"{modelType}_{targetedBuilding.buildingType.Value}_{Game1.currentSeason}";
-                        AssignDefaultModData(farm, instanceSeasonName, true);
-                    }
+                        isFarmerHouse = true;
 
-                    foreach (string key in farm.modData.Keys)
-                    {
-                        targetedBuilding.modData[key] = farm.modData[key];
+                        targetedBuilding = new Building();
+                        targetedBuilding.buildingType.Value = $"Farmhouse_{Game1.MasterPlayer.HouseUpgradeLevel}";
+                        targetedBuilding.tileX.Value = farmerHouse.tileX.Value;
+                        targetedBuilding.tileY.Value = farmerHouse.tileY.Value;
+                        targetedBuilding.tilesWide.Value = farmerHouse.tilesWide.Value;
+                        targetedBuilding.tilesHigh.Value = farmerHouse.tilesHigh.Value;
+
+                        var modelType = AlternativeTextureModel.TextureType.Building;
+                        if (!farm.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME) || !farm.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME].Contains(targetedBuilding.buildingType.Value))
+                        {
+                            var instanceSeasonName = $"{modelType}_{targetedBuilding.buildingType.Value}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
+                            AssignDefaultModData(farm, instanceSeasonName, true);
+                        }
+
+                        foreach (string key in farm.modData.Keys)
+                        {
+                            targetedBuilding.modData[key] = farm.modData[key];
+                        }
                     }
                 }
 
@@ -305,7 +307,7 @@ namespace AlternativeTextures.Framework.Patches.Tools
                     if (!targetedBuilding.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME))
                     {
                         var modelType = AlternativeTextureModel.TextureType.Building;
-                        var instanceSeasonName = $"{modelType}_{targetedBuilding.buildingType.Value}_{Game1.currentSeason}";
+                        var instanceSeasonName = $"{modelType}_{targetedBuilding.buildingType.Value}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                         AssignDefaultModData(targetedBuilding, instanceSeasonName, true);
                     }
 
@@ -364,11 +366,11 @@ namespace AlternativeTextures.Framework.Patches.Tools
                 // Assign default data if none exists
                 if (!targetedObject.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME))
                 {
-                    var instanceSeasonName = $"{GetTextureType(targetedObject)}_{GetObjectName(targetedObject)}_{Game1.currentSeason}";
+                    var instanceSeasonName = $"{GetTextureType(targetedObject)}_{GetObjectName(targetedObject)}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                     AssignDefaultModData(targetedObject, instanceSeasonName, true);
                 }
 
-                var itemId = $"{GetTextureType(targetedObject)}_{targetedObject.ItemId}_{Game1.currentSeason}";
+                var itemId = $"{GetTextureType(targetedObject)}_{targetedObject.ItemId}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                 var modelName = targetedObject.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME].Replace($"{targetedObject.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER]}.", String.Empty);
                 if (targetedObject.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(targetedObject.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]))
                 {
@@ -378,7 +380,7 @@ namespace AlternativeTextures.Framework.Patches.Tools
 
                 if (AlternativeTextures.textureManager.GetAvailableTextureModels(itemId, modelName, Game1.GetSeasonForLocation(Game1.currentLocation)).Count == 0)
                 {
-                    var instanceSeasonName = $"{GetTextureType(targetedObject)}_{GetObjectName(targetedObject)}_{Game1.currentSeason}";
+                    var instanceSeasonName = $"{GetTextureType(targetedObject)}_{GetObjectName(targetedObject)}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                     AssignDefaultModData(targetedObject, instanceSeasonName, true);
 
                     modelName = targetedObject.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME].Replace($"{targetedObject.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER]}.", String.Empty);
@@ -591,14 +593,14 @@ namespace AlternativeTextures.Framework.Patches.Tools
                 var modelType = AlternativeTextureModel.TextureType.Character;
                 if (!character.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME))
                 {
-                    var instanceSeasonName = $"{modelType}_{GetCharacterName(character)}_{Game1.currentSeason}";
+                    var instanceSeasonName = $"{modelType}_{GetCharacterName(character)}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                     AssignDefaultModData(character, instanceSeasonName, true);
                 }
 
                 var modelName = character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_NAME].Replace($"{character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_OWNER]}.", String.Empty);
                 if (modelName.Contains(GetCharacterName(character), StringComparison.OrdinalIgnoreCase) is false)
                 {
-                    modelName = $"{modelType}_{GetCharacterName(character)}_{Game1.currentSeason}";
+                    modelName = $"{modelType}_{GetCharacterName(character)}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                 }
 
                 if (character.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_SEASON) && !String.IsNullOrEmpty(character.modData[ModDataKeys.ALTERNATIVE_TEXTURE_SEASON]))

--- a/AlternativeTextures/Framework/UI/PaintBucketMenu.cs
+++ b/AlternativeTextures/Framework/UI/PaintBucketMenu.cs
@@ -636,7 +636,7 @@ namespace AlternativeTextures.Framework.UI
                         var farmerHouse = mailBoxFarm.GetMainFarmHouse();
                         if (farmerHouse.modData.ContainsKey(ModDataKeys.ALTERNATIVE_TEXTURE_NAME) is false)
                         {
-                            var instanceSeasonName = $"{TextureType.Building}_{$"Farmhouse_{Game1.MasterPlayer.HouseUpgradeLevel}"}_{Game1.currentSeason}";
+                            var instanceSeasonName = $"{TextureType.Building}_{$"Farmhouse_{Game1.MasterPlayer.HouseUpgradeLevel}"}_{Game1.GetSeasonForLocation(Game1.currentLocation)}";
                             PatchTemplate.AssignDefaultModData(farmerHouse, instanceSeasonName, true);
                         }
                     }
@@ -863,7 +863,7 @@ namespace AlternativeTextures.Framework.UI
                             }
                             else if (Game1.currentLocation is Farm mailBoxFarm && mailBoxFarm.GetMainMailboxPosition() is Point mailboxPosition && PatchTemplate.IsPositionNearMailbox(Game1.currentLocation, mailboxPosition, (int)(_position.X / 64), (int)(_position.Y / 64)))
                             {
-                                Texture2D mailboxTexture = Game1.content.Load<Texture2D>($"Maps\\{Game1.currentSeason.ToLower()}_outdoorsTileSheet");
+                                Texture2D mailboxTexture = Game1.content.Load<Texture2D>($"Maps\\{Game1.GetSeasonForLocation(Game1.currentLocation).ToString().ToLower()}_outdoorsTileSheet");
                                 b.Draw(mailboxTexture, new Vector2(this.availableTextures[i].bounds.X, this.availableTextures[i].bounds.Y), new Rectangle(80, 1232, 16, 32), Color.White, 0f, new Vector2(0f, 0f), 4f, SpriteEffects.None, 0.89f);
                             }
                             else if (PatchTemplate.GetBuildingAt(Game1.currentLocation, (int)_position.X, (int)_position.Y) is Building building)


### PR DESCRIPTION
### Features:
- (2a30693928a6d8c92383a46196c136d9e6079af2) Added support for all buildable locations by replacing `is Farm` type checks with the more generalized `IsBuildableLocation()` method. Additionally, occurrences of `Game1.currentSeason` have been replaced with `Game1.GetSeasonForLocation(Game1.currentLocation)` to use the season applied to the location, rather than the global season (see [LocationContexts](https://stardewvalleywiki.com/Modding:Migrate_to_Stardew_Valley_1.6#Custom_location_contexts)' `SeasonOverride` field).
### Fixes:
- (85bcdfec45041da36fdf5ce65d185c917d392008) Fixed console command `at_spawn_gc`, which has not been working correctly (probably since version 1.6.0).